### PR TITLE
Feature/set process priorities

### DIFF
--- a/base-files/eatsa-user/home/eatsa/.profile
+++ b/base-files/eatsa-user/home/eatsa/.profile
@@ -24,7 +24,8 @@ PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 #export XAUTHORITY=/tmp/Xauthority
 export DISPLAY=:0
 
-# run supervisor?  It doesn't seem to display the gui correctly, but X does start.
+# Initiate upgrade in background.
+sudo supervisorctl start wise-upgrade
 
 # this is the command that supervisor runs.  Our issue now is what happens when this process dies.
-exec /usr/bin/startx
+exec nice -n -10 /usr/bin/startx


### PR DESCRIPTION
Depends on #6 

Calls upgrade process when eatsa user's .profile file is processed.
Makes `startx` higher priority than the background upgrade process.