### PR TITLE
Feature/fix sha256file bad file list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SCRIPTS = $(shell find . -type f -name "*.sh" -not -path "./workspace/*" -not -p
 SHELL_FILES = base-files/eatsa-user/etc/X11/Xsession.d/80x11-wise-xsession \
 	base-files/boot-customization/usr/share/initramfs-tools/hooks/eatsa-initrd-hook
 BASH_FILES = base-files/base-system/etc/network/if-up.d/wise-ifpreup-hostname \
-	base-files/base-system/etc/network/if-up.d/wise-ifup-hostname
+	base-files/base-system/etc/network/if-up.d/wise-ifup-hostname \
+	base-files/eatsa-user/home/eatsa/.profile
 
 # depends on shellcheck 0.4.6+.  Will fail on 0.3.3.
 .PHONY: shellcheck

--- a/base-files/eatsa-user/home/eatsa/.profile
+++ b/base-files/eatsa-user/home/eatsa/.profile
@@ -12,6 +12,7 @@
 if [ -n "$BASH_VERSION" ]; then
     # include .bashrc if it exists
     if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck disable=SC1090
 	. "$HOME/.bashrc"
     fi
 fi

--- a/dist_full_img.sh
+++ b/dist_full_img.sh
@@ -32,5 +32,7 @@ popd
 mv "${work_output_image}.xz" "${dist}/${output_image_file}-${build_version}.xz"
 cp "${workspace}/filesystem-odroid_c2.squashfs" "${dist}/filesystem-odroid_c2-${build_version}.squashfs"
 
-shasum -a 256 "${dist}/${output_image_file}-${build_version}.xz" > "${dist}/${output_image_file}-${build_version}.xz.sha256sum"
-shasum -a 256 "${dist}/filesystem-odroid_c2-${build_version}.squashfs" > "${dist}/filesystem-odroid_c2-${build_version}.squashfs.sha256sum"
+pushd "${dist}" || exit 1
+shasum -a 256 "${output_image_file}-${build_version}.xz" > "${output_image_file}-${build_version}.xz.sha256sum"
+shasum -a 256 "filesystem-odroid_c2-${build_version}.squashfs" > "filesystem-odroid_c2-${build_version}.squashfs.sha256sum"
+popd || exit 1

--- a/dockerfiles/ubuntu-xenial/Dockerfile
+++ b/dockerfiles/ubuntu-xenial/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial-20181005
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y debootstrap \
-    qemu-user-static curl git build-essential gnupg sudo parted dosfstools \
-    squashfs-tools xz-utils udev vim && \
+    binfmt-support qemu-user-static curl git build-essential gnupg sudo \
+    parted dosfstools squashfs-tools xz-utils udev vim && \
     update-binfmts --enable qemu-aarch64
 
 ENV USER=root \

--- a/partition_utils.sh
+++ b/partition_utils.sh
@@ -83,7 +83,7 @@ pt_utils_create_partitions() {
     # resize partition 2 - From sector 264192, + 4194304 sectors, - 1 for end of sector
     # partition 3 - from 4458496s, +4194304s, - 1 for end of sector
     # partition 4 - from 8652800s until end of disk
-    parted /dev/loop0 -s -- resizepart 2 4458495s \
+    parted "${loop_device}" -s -- resizepart 2 4458495s \
       mkpart primary ext2 4458496s 8652799s \
       mkpart primary ext2 8652800s -1s
 


### PR DESCRIPTION
Depends on #6 

In testing, the `wise-upgrade.sh` script was looking for a http path of `.../dist/filename` where `.../dist` was not expected.  This came from the `shasum` being executed a directory away.  The PR fixes that by moving into the `dist` directory before performing shasum.