### PR TITLE
Feature/remove chrome cache dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 # travis-ci will timeout the build otherwise.  xz takes a long time (more than)
 # 10 minutes to run when zipping, and travis times out after 10 minutes.
 script:
-- make dist
+- if [ $TRAVIS_EVENT_TYPE == "pull_request" ]; then make build; else make dist; fi
 # below lines used for debugging travis issues.
 #- make build
 #- ./run_build_env.sh ubuntu-xenial ./dist_full_img.sh

--- a/base-files/eatsa-user/etc/X11/Xsession.d/80x11-wise-xsession
+++ b/base-files/eatsa-user/etc/X11/Xsession.d/80x11-wise-xsession
@@ -107,6 +107,7 @@ fi
 # this loop also prevents any further xsession scripts from running
 # NOTE: some odd reason, chromium does not like multi-line options and this script doesn't expand args correctly!
 while true; do
+    rm -rf ~/.config/chromium
     /usr/bin/chromium-browser \
       --incognito --allow-running-insecure-content --no-first-run --autoplay-policy=no-user-gesture-required --video-threads=4 \
       "${chromium_mode}" \

--- a/base-files/eatsa-user/etc/X11/address.html
+++ b/base-files/eatsa-user/etc/X11/address.html
@@ -1,5 +1,13 @@
 <head><style>
 body {background-color:black;}
-h1 {color:white; position:absolute; top:40%; right:10%; font-size:150px; transform:rotate(-180deg);}
+h1 {
+    color:white;
+    position:absolute;
+    top:40%;
+    right:10%;
+    font-size:48px;
+    transform: scaleX(-1);
+    filter: FlipH;
+}
 </style></head>
 <body><h1>%%TEXT%%</h1></body>


### PR DESCRIPTION
1. Remove chromium cache dir so that chrome will always startup clean.
2. Shrink the mac address text for debugging purposes, as the resolution on the shelves are smaller than the cubbies.
3. Make PR builds take 1/2 as long as full builds.  Full builds just zips the final image file.