### PR TITLE
Feature/ssh eatsa user skip startx

### DIFF
--- a/base-files/base-system/etc/network/if-up.d/wise-ifpreup-hostname
+++ b/base-files/base-system/etc/network/if-up.d/wise-ifpreup-hostname
@@ -1,5 +1,8 @@
 #!/bin/bash
 # /deploy/wise-display/
+#
+# This was ported from wise-display builds for nuc_5ix and odroid_xu4
+# However, using systemd-networkd seems to be better for ubuntu 16.04 and odroid-c2's
 
 echo "Starting $0"
 

--- a/base-files/base-system/etc/resolvconf.conf
+++ b/base-files/base-system/etc/resolvconf.conf
@@ -1,0 +1,2 @@
+# Set to NO to disable resolvconf from running any subscribers. Defaults to YES.
+resolvconf=NO

--- a/base-files/base-system/etc/systemd/network/04-eth.network
+++ b/base-files/base-system/etc/systemd/network/04-eth.network
@@ -1,0 +1,12 @@
+[Match]
+Name=e*
+[Network]
+DHCP=ipv4
+IPv6AcceptRA=no
+LinkLocalAddressing=no
+# to use static IP uncomment these instead of DHCP
+#Address=192.168.1.86/24
+#Gateway=192.168.1.1
+[DHCP]
+RouteMetric=10
+UseDomains=yes

--- a/base-files/eatsa-user/etc/X11/Xsession.d/80x11-wise-xsession
+++ b/base-files/eatsa-user/etc/X11/Xsession.d/80x11-wise-xsession
@@ -12,6 +12,8 @@
 # hide the pointer afte 1sec
 /usr/bin/unclutter -idle 1 -root &
 
+# This code and also the code that writes /tmp/address.html should live closer
+# to a network up/down part of the code, regardless of X11 starting up.
 # The file is called netboot-if.conf, but it is used regardless of netboot-ing.
 if [ -r /etc/netboot-if.conf ]; then
     # shellcheck disable=SC1091
@@ -38,10 +40,14 @@ elif [ -n "$WISE_ROLE" ] && [ -n "$WISE_ID" ]; then
 elif ! nc -w1 -z storemanager 3000 || [ "$number" -lt 201 ] || [ "$number" -gt 230 ]; then
     if [ -z "$number" ]; then
         # we have no network connection
-        cubby="$eth_mac"
+        cubby="$eth_mac_full"
     else
         # we have an IP address but it's not a cubby address
         cubby="$IPV4ADDR $eth_mac_full"
+    fi
+
+    if [ -z "$cubby" ]; then
+        cubby="Could not find MAC address nor IP address"
     fi
     sed -e "s,%%TEXT%%,$cubby," /etc/X11/address.html > /tmp/address.html
     WISE_URL="file:///tmp/address.html"

--- a/base-files/eatsa-user/home/eatsa/.profile
+++ b/base-files/eatsa-user/home/eatsa/.profile
@@ -24,8 +24,12 @@ PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 #export XAUTHORITY=/tmp/Xauthority
 export DISPLAY=:0
 
-# Initiate upgrade in background.
-sudo supervisorctl start wise-upgrade
+# If the user accesses with SSH and eatsa user, don't try to run X
+if [ -z "$SSH_CLIENT" ]; then
+    # Initiate upgrade in background.
+    sudo supervisorctl start wise-upgrade
 
-# this is the command that supervisor runs.  Our issue now is what happens when this process dies.
-exec nice -n -10 /usr/bin/startx
+    # this is the command that supervisor runs.  Our issue now is what happens when this process dies.
+    #exec nice -n -10 /usr/bin/startx
+    exec /usr/bin/startx
+fi

--- a/base-files/supervisor-scripts/etc/supervisor/conf.d/supd-wise-refresh.conf
+++ b/base-files/supervisor-scripts/etc/supervisor/conf.d/supd-wise-refresh.conf
@@ -1,0 +1,13 @@
+# /etc/supervisor/conf.d/
+
+[program:wise-refresh]
+environment=XAUTHORITY="/tmp/Xauthority", DISPLAY=":0"
+command=/usr/bin/xdotool key F5
+user=eatsa
+
+autostart=false
+autorestart=false
+startsecs=0
+
+stderr_logfile=syslog
+stdout_logfile=syslog

--- a/install_base_system.sh
+++ b/install_base_system.sh
@@ -47,13 +47,19 @@ run_install_base_system() {
     chroot "${rootfs_dir}" systemctl mask apt-daily.timer
     chroot "${rootfs_dir}" systemctl mask unattended-upgrades.service
 
+    # Use systemd-networkd to detect network events
+    # see https://raspberrypi.stackexchange.com/questions/78787/howto-migrate-from-networking-to-systemd-networkd-with-dynamic-failover
+    chroot "${rootfs_dir}" systemctl disable networking
+    chroot "${rootfs_dir}" systemctl enable systemd-networkd
+    chroot "${rootfs_dir}" systemctl enable systemd-resolved
+
     # The old wise-display devices run everything as root and the software now,
     # such as chromium, does not support running as root without lots of banners
     # showing up on the display that are un-removable.
     #chroot "${rootfs_dir}" systemctl enable supervisor
     chroot "${rootfs_dir}" systemctl enable acpid
 
-    # We use supervisor to manage nginx.
+    # no reason to run nginx on a wise-display / display-manager client.
     chroot "${rootfs_dir}" systemctl mask nginx.service
 
     # Remove default nginx files


### PR DESCRIPTION
Allows eatsa user to ssh into the device.
Makes networking a little bit better
  - network cable plug detection works (address.html won't get updated though)
  - address.html displays more useful message if the network cable isn't plugged in.